### PR TITLE
rename cross sell to post purchase

### DIFF
--- a/scripts/generate/templates/react.template
+++ b/scripts/generate/templates/react.template
@@ -1,7 +1,7 @@
 import React from 'react';
 import {renderReact, Text} from '@shopify/argo-checkout-testing';
 
-renderReact('Checkout::PostPurchaseCrossSell::Render', (props) => (
+renderReact('Checkout::PostPurchase::Render', (props) => (
   <Extension {...props} />
 ));
 

--- a/scripts/generate/templates/vanilla.template
+++ b/scripts/generate/templates/vanilla.template
@@ -1,6 +1,6 @@
 import {extend, Text} from '@shopify/argo-checkout-testing';
 
-extend('Checkout::PostPurchaseCrossSell::Render', (root, input) => {
+extend('Checkout::PostPurchase::Render', (root, input) => {
   const text = root.createComponent(Text);
   text.appendChild('Create your awesome offer page here.');
 


### PR DESCRIPTION
We renamed the extension points in checkout-web. 

https://github.com/Shopify/checkout-web/pull/1546