### PR TITLE
Remove `main` from `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "engines": {
     "node": ">=10.16.0"
   },
-  "main": "extension.ts",
   "repository": "https://github.com/Shopify/argo-checkout-template.git",
   "author": "Shopify <app-extensions@shopify.com>",
   "license": "MIT",


### PR DESCRIPTION
Appears unused; removing.  If kept, the value should have been build/extension.js