### PR TITLE
Two column layout with bottom span

### DIFF
--- a/scripts/generate/templates/react.template.tsx
+++ b/scripts/generate/templates/react.template.tsx
@@ -11,8 +11,17 @@ import {
   extend,
   render,
   useExtensionInput,
+  BlockStack,
   Button,
+  CalloutBanner,
+  Heading,
+  HeadingGroup,
+  Image,
+  InlineStack,
+  Separator,
   Text,
+  TextBlock,
+  TextContainer,
 } from '@shopify/argo-checkout-react';
 
 /** Define any shape or type of data */
@@ -59,24 +68,72 @@ async function getRenderData() {
 render('Checkout::PostPurchase::Render', () => <App />);
 
 // Top-level React component
-function App() {
+export function App() {
   const {extensionPoint, storage} = useExtensionInput<
     'Checkout::PostPurchase::Render'
   >();
-  const initialState = storage.initialData;
+  const initialState = storage.initialData as InitialState;
   return (
-    <>
-      <Text>
-        Create your awesome post purchase page here. initialState=
-        {JSON.stringify(initialState)}
-      </Text>
-      <Button
-        onPress={() => {
-          console.log(`Extension point ${extensionPoint}`);
-        }}
+    <BlockStack>
+      <CalloutBanner
+        title={`The body of this page was rendered by ${extensionPoint}`}
       >
-        Log extension point to console
-      </Button>
-    </>
+        subtext
+      </CalloutBanner>
+      {/* InlineStack is a temporary to create columns.  A new layout component will be
+          available soon that provides responsive UI and more control over widths. */}
+      <InlineStack>
+        <BlockStack>
+          <Heading>Left Column</Heading>
+          <Image source="https://cdn.shopify.com/assets/images/logos/shopify-bag.png" />
+        </BlockStack>
+        <BlockStack alignment="leading">
+          <TextContainer>
+            <Heading>Right Column</Heading>
+            <HeadingGroup>
+              <Heading>My Post-Purchase Extension</Heading>
+              <TextBlock>
+                It could be a cross-sell extension, product review for past
+                purchases, request for more information from the buyer, or
+                anything else
+              </TextBlock>
+              <HeadingGroup>
+                <Heading>Description</Heading>
+                <TextBlock>
+                  This is a non-exhaustive example, demonstrating provided UI
+                  components
+                </TextBlock>
+                <Heading>initialState</Heading>
+                <TextBlock>{JSON.stringify(initialState)}</TextBlock>
+              </HeadingGroup>
+            </HeadingGroup>
+          </TextContainer>
+          <Button
+            onPress={() => {
+              console.log(`Extension point ${extensionPoint}`);
+            }}
+          >
+            Log extension point to console
+          </Button>
+        </BlockStack>
+      </InlineStack>
+      <Separator />
+      <TextContainer spacing="loose" alignment="center">
+        <TextBlock>
+          Bottom Text <Text emphasized>Stretches </Text>
+          across both columns. Bottom Text Stretches across both columns. Bottom
+          Text Stretches across both columns. Bottom Text Stretches across both
+          columns. Bottom Text Stretches across both columns. Bottom Text
+          Stretches across both columns.
+        </TextBlock>
+        <TextBlock>
+          In the <Text role="deletion">First</Text> Second Paragraph, Bottom
+          Text Stretches across both columns. Bottom Text Stretches across both
+          columns. Bottom Text Stretches across both columns. Bottom Text
+          Stretches across both columns. Bottom Text Stretches across both
+          columns. Bottom Text Stretches across both columns.
+        </TextBlock>
+      </TextContainer>
+    </BlockStack>
   );
 }

--- a/scripts/generate/templates/vanilla.template.ts
+++ b/scripts/generate/templates/vanilla.template.ts
@@ -6,7 +6,20 @@
  *     completes
  */
 
-import {extend, Button, Text} from '@shopify/argo-checkout';
+import {
+  extend,
+  BlockStack,
+  Button,
+  Heading,
+  HeadingGroup,
+  Image,
+  InlineStack,
+  Separator,
+  Text,
+  TextBlock,
+  TextContainer,
+  CalloutBanner,
+} from '@shopify/argo-checkout';
 
 /** Define any shape or type of data */
 interface InitialState {
@@ -51,21 +64,82 @@ async function getRenderData() {
  */
 extend('Checkout::PostPurchase::Render', (root, {extensionPoint, storage}) => {
   const initialState = storage.initialData as InitialState;
-  const text = root.createComponent(Text);
-  text.appendChild(
-    `Create your awesome post purchase page here. initialState=${JSON.stringify(
-      initialState
-    )}`
-  );
-  root.appendChild(text);
 
-  const button = root.createComponent(Button, {
-    onPress: () => {
-      console.log(`Extension point ` + extensionPoint);
-    },
-  });
-  button.appendChild('Log extension point to console');
-  root.appendChild(button);
+  root.appendChild(
+    root.createComponent(BlockStack, {}, [
+      root.createComponent(
+        CalloutBanner,
+        {
+          title: `The body of this page was rendered by ${extensionPoint}`,
+        },
+        'subtext'
+      ),
+      /* InlineStack is a temporary to create columns.  A new layout component will be
+         available soon that provides responsive UI and more control over widths. */
+      root.createComponent(InlineStack, {}, [
+        root.createComponent(BlockStack, {}, [
+          root.createComponent(Heading, {}, 'Left Column'),
+          root.createComponent(Image, {
+            source:
+              'https://cdn.shopify.com/assets/images/logos/shopify-bag.png',
+          }),
+        ]),
+        root.createComponent(BlockStack, {}, [
+          root.createComponent(TextContainer, {}, [
+            root.createComponent(Heading, {}, 'Right Column'),
+            root.createComponent(HeadingGroup, {}, [
+              root.createComponent(Heading, {}, 'My Post-Purchase Extension'),
+              root.createComponent(
+                TextBlock,
+                {},
+                'It could be a cross-sell extension, product review for past purchases, request for more information from the buyer, or anything else'
+              ),
+              root.createComponent(HeadingGroup, {}, [
+                root.createComponent(Heading, {}, 'Description'),
+                root.createComponent(
+                  TextBlock,
+                  {},
+                  'This is a non-exhaustive example, demonstrating provided UI components'
+                ),
+                root.createComponent(Heading, {}, 'initialState'),
+                root.createComponent(
+                  TextBlock,
+                  {},
+                  JSON.stringify(initialState)
+                ),
+              ]),
+            ]),
+          ]),
+          root.createComponent(
+            Button,
+            {
+              onPress: () => {
+                console.log(`Extension point ${extensionPoint}`);
+              },
+            },
+            'Log extension point to console'
+          ),
+        ]),
+      ]),
+      root.createComponent(Separator),
+      root.createComponent(
+        TextContainer,
+        {spacing: 'loose', alignment: 'center'},
+        [
+          root.createComponent(TextBlock, {}, [
+            'Bottom Text ',
+            root.createComponent(Text, {emphasized: true}, 'Stretches'),
+            ' across both columns. Bottom Text Stretches across both columns. Bottom Text Stretches across both columns. Bottom Text Stretches across both columns. Bottom Text Stretches across both columns. Bottom Text Stretches across both columns.',
+          ]),
+          root.createComponent(TextBlock, {}, [
+            'In the ',
+            root.createComponent(Text, {role: 'deletion'}, 'First'),
+            ' Second Paragraph, Bottom Text Stretches across both columns. Bottom Text Stretches across both columns. Bottom Text Stretches across both columns. Bottom Text Stretches across both columns. Bottom Text Stretches across both columns. Bottom Text Stretches across both columns.',
+          ]),
+        ]
+      ),
+    ])
+  );
 
   root.mount();
 });


### PR DESCRIPTION
Fixes: https://github.com/Shopify/cross-sell-app/issues/65

Note that some layout components are *not* included:
- View
- Tiles
- Extension `Layout` - https://github.com/Shopify/checkout-web/pull/1721

Some nice-to-have functionality is absent:
- Not responsive (always two columns, even on small screens)
- Column widths are not settable (driven by the Left Column's Image width)

![image](https://user-images.githubusercontent.com/9967320/85785883-b8b0e700-b6f7-11ea-8d91-0743f257cf8a.png)

