### PR TITLE
Add extension.config.yml to generated project

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-react": "^7.20.5",
+    "fs-extra": "^9.0.1",
     "inquirer": "^7.3.3",
     "prettier": "^2.0.5",
     "ts-node": "^8.10.2",

--- a/scripts/generate/clean-up.ts
+++ b/scripts/generate/clean-up.ts
@@ -10,6 +10,7 @@ export function cleanUp() {
   delete json.scripts.generate;
   delete json.scripts['clean-up'];
   delete json.devDependencies['@types/yargs'];
+  delete json.devDependencies['fs-extra'];
   delete json.devDependencies['inquirer'];
   delete json.devDependencies['ts-node'];
   delete json.devDependencies['yargs'];

--- a/scripts/generate/templates/files/extension.config.yml
+++ b/scripts/generate/templates/files/extension.config.yml
@@ -1,0 +1,6 @@
+---
+# metafields:
+#   - namespace: my-namespace
+#     key: my-key
+#   - namespace: my-namespace
+#     key: my-key-2

--- a/yarn.lock
+++ b/yarn.lock
@@ -3134,7 +3134,7 @@ from2@^2.1.0:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
 
-fs-extra@^9.0.0:
+fs-extra@^9.0.0, fs-extra@^9.0.1:
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.0.1.tgz#910da0062437ba4c39fedd863f1675ccfefcb9fc"
   integrity sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==


### PR DESCRIPTION
Adds empty config (with comments for metafields) to template

🎩 

```
yarn
yarn generate --type=CHECKOUT_POST_PURCHASE
yarn start
```

ensure `extension.config.yml` exists in root folder and that script (react/ts/vanila) is still generated and works.
Check that `fs-extra` is deleted from `package.json` after generation.

fixes https://github.com/Shopify/cross-sell-app/issues/250