### PR TITLE
Support template arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm run generate -- --type=CHECKOUT_POST_PURCHASE
 ## With yarn
 yarn
 
-yarn generate --type=CHECKOUT_POST_PURCHASE
+yarn generate --type=CHECKOUT_POST_PURCHASE --template=vanilla-typescript
 ```
 
 ### Available extensions

--- a/scripts/generate/index.ts
+++ b/scripts/generate/index.ts
@@ -5,8 +5,43 @@ import {cleanUp} from './clean-up';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const inquirer = require('inquirer');
 
+function validateTemplateIdentifier(templateIdentifier: string): Template {
+  if (isTemplate(templateIdentifier)) {
+    return templateIdentifier;
+  }
+  throw new Error(`Unknown template: ${templateIdentifier}`);
+}
+
+function isTemplate(
+  templateIdentifier: string
+): templateIdentifier is Template {
+  for (const key in Template) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    if ((Template as any)[key] === templateIdentifier) {
+      return true;
+    }
+  }
+  return false;
+}
+
+async function getTemplateIdentifier() {
+  const response = await inquirer.prompt([
+    {
+      type: 'list',
+      name: 'template',
+      message: 'Select template:',
+      min: 1,
+      max: 1,
+      instructions: false,
+      choices: Object.values(Template),
+    },
+  ]);
+  const {template} = response;
+  return template;
+}
+
 (async () => {
-  const {type: extensionPoint} = yargs.argv;
+  const {type: extensionPoint, template: templateIdentifier} = yargs.argv;
   console.log('Create ', extensionPoint, ' extension project');
   if (!extensionPoint) {
     console.error(
@@ -19,19 +54,9 @@ See README.md for instructions.
     return;
   }
 
-  const response = await inquirer.prompt([
-    {
-      type: 'list',
-      name: 'template',
-      message: 'Select template:',
-      min: 1,
-      max: 1,
-      instructions: false,
-      choices: ['vanilla', 'react', 'vanilla-typescript', 'react-typescript'],
-    },
-  ]);
-
-  const {template} = response;
+  const template = templateIdentifier
+    ? validateTemplateIdentifier(templateIdentifier as string)
+    : await getTemplateIdentifier();
 
   console.log('✅ You selected:', template);
 


### PR DESCRIPTION
This PR adds support for template arg to bypass the template inquirer. It also changes template wording to [language-framework] to match Argo Admin. 

Before:
```
? Select template: 
  vanilla 
  react 
  vanilla-typescript 
❯ react-typescript 
```

After:
```
? Select template: 
  javascript 
  typescript 
  javascript-react 
❯ typescript-react 
```

Resolves https://github.com/Shopify/argo-admin-private/issues/1370

## How to test?
- Run `yarn generate --type=CHECKOUT_POST_PURCHASE`. Verify that the template inquirer shows up and extension is generated as normal.
- Run `yarn generate --type=CHECKOUT_POST_PURCHASE --template=vanilla-typescript`. Verify that the template inquirer doesn't show up and extension is generated as normal.