### PR TITLE
Updating post-purchase template

### DIFF
--- a/scripts/generate/templates/post-purchase/src/index.ts
+++ b/scripts/generate/templates/post-purchase/src/index.ts
@@ -13,7 +13,6 @@ import {
   Heading,
   Image,
   Layout,
-  Link,
   TextBlock,
   TextContainer,
   CalloutBanner,
@@ -96,18 +95,6 @@ extend('Checkout::PostPurchase::Render', (root, {extensionPoint, storage}) => {
                 {},
                 'Here you can cross-sell other products, request a product review based on a previous purchase, and much more.'
               ),
-              root.createComponent(TextBlock, {}, [
-                'Learn more about ',
-                root.createComponent(
-                  Link,
-                  {
-                    to: 'https://shopify.dev',
-                    external: true,
-                  },
-                  'creating great user experiences for post-purchase offers'
-                ),
-                '.',
-              ]),
             ]),
             root.createComponent(
               Button,

--- a/scripts/generate/templates/post-purchase/src/index.ts
+++ b/scripts/generate/templates/post-purchase/src/index.ts
@@ -11,14 +11,13 @@ import {
   BlockStack,
   Button,
   Heading,
-  HeadingGroup,
   Image,
   Layout,
-  Separator,
-  Text,
+  Link,
   TextBlock,
   TextContainer,
   CalloutBanner,
+  View,
 } from '@shopify/argo-post-purchase';
 
 /** Define any shape or type of data */
@@ -34,24 +33,23 @@ interface InitialState {
  * extension point.
  */
 extend('Checkout::PostPurchase::ShouldRender', async ({storage}) => {
-  const {render, initialState} = await getRenderData();
+  const initialState = await getRenderData();
+  const render = true;
+
   if (render) {
-    // Saves payload data, provided to `Render` via `storage.initialData`
+    // Saves initial state, provided to `Render` via `storage.initialData`
     await storage.update(initialState);
   }
+
   return {
     render,
   };
 });
 
 // Simulate results of network call, etc.
-async function getRenderData() {
-  const initialState: InitialState = {
-    couldBe: 'anything',
-  };
+async function getRenderData(): Promise<InitialState> {
   return {
-    render: true,
-    initialState,
+    couldBe: 'anything',
   };
 }
 
@@ -66,92 +64,65 @@ extend('Checkout::PostPurchase::Render', (root, {extensionPoint, storage}) => {
   const initialState = storage.initialData as InitialState;
 
   root.appendChild(
-    root.createComponent(BlockStack, {}, [
+    root.createComponent(BlockStack, {spacing: 'loose'}, [
       root.createComponent(
         CalloutBanner,
-        {
-          title: `The body of this page was rendered by ${extensionPoint}`,
-        },
-        'subtext'
+        {title: 'Post-purchase extension template'},
+        'Use this template as a starting point to build a great post-purchase extension.'
       ),
-      /* <Layout />
-       * `500` represents `500px`
-       * `0.5` represents `50%`
-       * `1` represents `100%` */
       root.createComponent(
         Layout,
         {
+          maxInlineSize: 0.95,
           media: [
-            {viewportSize: 'small', sizes: [1, 1], maxInlineSize: 0.95},
-            {viewportSize: 'medium', sizes: [300, 0.5], maxInlineSize: 0.95},
-            {viewportSize: 'large', sizes: [300, 0.3], maxInlineSize: 0.95},
+            {viewportSize: 'small', sizes: [1, 30, 1]},
+            {viewportSize: 'medium', sizes: [300, 30, 0.5]},
+            {viewportSize: 'large', sizes: [400, 30, 0.33]},
           ],
         },
         [
-          root.createComponent(BlockStack, {}, [
-            root.createComponent(Heading, {}, 'Left Column'),
+          root.createComponent(View, {}, [
             root.createComponent(Image, {
               source:
-                'https://cdn.shopify.com/assets/images/logos/shopify-bag.png',
+                'https://cdn.shopify.com/static/images/examples/img-placeholder-1120x1120.png',
             }),
           ]),
-          root.createComponent(BlockStack, {}, [
+          root.createComponent(View),
+          root.createComponent(BlockStack, {spacing: 'xloose'}, [
             root.createComponent(TextContainer, {}, [
-              root.createComponent(Heading, {}, 'Right Column'),
-              root.createComponent(HeadingGroup, {}, [
-                root.createComponent(Heading, {}, 'My Post-Purchase Extension'),
+              root.createComponent(Heading, {}, 'Post-purchase extension'),
+              root.createComponent(
+                TextBlock,
+                {},
+                'Here you can cross-sell other products, request a product review based on a previous purchase, and much more.'
+              ),
+              root.createComponent(TextBlock, {}, [
+                'Learn more about ',
                 root.createComponent(
-                  TextBlock,
-                  {},
-                  'It could be a cross-sell extension, product review for past purchases, request for more information from the buyer, or anything else'
+                  Link,
+                  {
+                    to: 'https://shopify.dev',
+                    external: true,
+                  },
+                  'creating great user experiences for post-purchase offers'
                 ),
-                root.createComponent(HeadingGroup, {}, [
-                  root.createComponent(Heading, {}, 'Description'),
-                  root.createComponent(
-                    TextBlock,
-                    {},
-                    'This is a non-exhaustive example, demonstrating provided UI components'
-                  ),
-                ]),
+                '.',
               ]),
             ]),
             root.createComponent(
               Button,
               {
+                submit: true,
                 onPress: () => {
-                  // eslint-disable-next-line no-console
-                  console.log(
-                    `Extension point ${extensionPoint}`,
-                    initialState
-                  );
+                  // eslint-disable-next-line
+                  console.log(`Extension point ${extensionPoint}`, initialState);
                 },
               },
-              'Log extension point to console'
+              'Primary button'
             ),
           ]),
         ]
       ),
-      root.createComponent(Layout, {maxInlineSize: 0.8}, [
-        root.createComponent(BlockStack, {}, [
-          root.createComponent(Separator),
-          root.createComponent(
-            TextContainer,
-            {spacing: 'loose', alignment: 'center'},
-            [
-              root.createComponent(TextBlock, {}, [
-                'Bottom Text ',
-                root.createComponent(Text, {emphasized: true}, 'Stretches'),
-                ' across both columns. Bottom Text Stretches across both columns. Bottom Text Stretches across both columns. Bottom Text Stretches across both columns. Bottom Text Stretches across both columns. Bottom Text Stretches across both columns.',
-              ]),
-              root.createComponent(TextBlock, {}, [
-                'In the ',
-                root.createComponent(Text, {role: 'deletion'}, 'First'),
-                ' Second Paragraph, Bottom Text Stretches across both columns. Bottom Text Stretches across both columns. Bottom Text Stretches across both columns. Bottom Text Stretches across both columns. Bottom Text Stretches across both columns. Bottom Text Stretches across both columns.',
-              ]),
-            ]
-          ),
-        ]),
-      ]),
     ])
   );
 

--- a/scripts/generate/templates/post-purchase/src/index.tsx
+++ b/scripts/generate/templates/post-purchase/src/index.tsx
@@ -1,8 +1,8 @@
 /**
  * Extend Shopify Checkout with a custom Post Purchase user experience.
  * This template provides two extension points:
- * 
- *  1. ShouldRender - Called first, during the checkout process, when the 
+ *
+ *  1. ShouldRender - Called first, during the checkout process, when the
  *     payment page loads.
  *  2. Render - If requested by `ShouldRender`, will be rendered after checkout
  *     completes
@@ -21,15 +21,13 @@ import {
   Link,
   TextBlock,
   TextContainer,
-  View
+  View,
 } from '@shopify/argo-post-purchase-react';
-
 
 /** Define any shape or type of data */
 interface InitialState {
   couldBe: 'anything' | 'everything';
 }
-
 
 /**
  * Entry point for the `ShouldRender` Extension Point.
@@ -38,7 +36,7 @@ interface InitialState {
  * optionally allows data to be stored on the client for use in the `Render`
  * extension point.
  */
- extend('Checkout::PostPurchase::ShouldRender', async ({storage}) => {
+extend('Checkout::PostPurchase::ShouldRender', async ({storage}) => {
   const initialState = await getRenderData();
   const render = true;
 
@@ -53,12 +51,11 @@ interface InitialState {
 });
 
 // Simulate results of network call, etc.
-async function getRenderData() : Promise<InitialState> {
+async function getRenderData(): Promise<InitialState> {
   return {
     couldBe: 'anything',
   };
 }
-
 
 /**
  * Entry point for the `Render` Extension Point
@@ -78,10 +75,9 @@ export function App() {
 
   return (
     <BlockStack spacing="loose">
-      <CalloutBanner
-        title="Post-purchase extension template"
-      >
-        Use this template as a starting point to build a great post-purchase extension.
+      <CalloutBanner title="Post-purchase extension template">
+        Use this template as a starting point to build a great post-purchase
+        extension.
       </CalloutBanner>
       <Layout
         maxInlineSize={0.95}
@@ -99,13 +95,19 @@ export function App() {
           <TextContainer>
             <Heading>Post-purchase extension</Heading>
             <TextBlock>
-              Here you can cross-sell other products, request a product review based on a previous purchase, and much more.
+              Here you can cross-sell other products, request a product review
+              based on a previous purchase, and much more.
             </TextBlock>
             <TextBlock>
-              Learn more about <Link to="https://shopify.dev" external>creating great user experiences for post-purchase offers</Link>.
+              Learn more about{' '}
+              <Link to="https://shopify.dev" external>
+                creating great user experiences for post-purchase offers
+              </Link>
+              .
             </TextBlock>
           </TextContainer>
-          <Button submit
+          <Button
+            submit
             onPress={() => {
               // eslint-disable-next-line no-console
               console.log(`Extension point ${extensionPoint}`, initialState);

--- a/scripts/generate/templates/post-purchase/src/index.tsx
+++ b/scripts/generate/templates/post-purchase/src/index.tsx
@@ -1,7 +1,9 @@
 /**
- * Extend Shopify Checkout with a custom Post Purchase user experience This
- * Shopify Checkout template provides two extension points:
- *  1. ShouldRender - Called first, during the checkout process.
+ * Extend Shopify Checkout with a custom Post Purchase user experience.
+ * This template provides two extension points:
+ * 
+ *  1. ShouldRender - Called first, during the checkout process, when the 
+ *     payment page loads.
  *  2. Render - If requested by `ShouldRender`, will be rendered after checkout
  *     completes
  */
@@ -14,19 +16,19 @@ import {
   Button,
   CalloutBanner,
   Heading,
-  HeadingGroup,
   Image,
   Layout,
-  Separator,
-  Text,
+  Link,
   TextBlock,
   TextContainer,
 } from '@shopify/argo-post-purchase-react';
+
 
 /** Define any shape or type of data */
 interface InitialState {
   couldBe: 'anything' | 'everything';
 }
+
 
 /**
  * Entry point for the `ShouldRender` Extension Point.
@@ -35,27 +37,27 @@ interface InitialState {
  * optionally allows data to be stored on the client for use in the `Render`
  * extension point.
  */
-extend('Checkout::PostPurchase::ShouldRender', async ({storage}) => {
-  const {render, initialState} = await getRenderData();
+ extend('Checkout::PostPurchase::ShouldRender', async ({storage}) => {
+  const render = true;
+  const initialState = await getRenderData();
+
   if (render) {
     // Saves initial state, provided to `Render` via `storage.initialData`
     await storage.update(initialState);
   }
+
   return {
     render,
   };
 });
 
 // Simulate results of network call, etc.
-async function getRenderData() {
-  const initialState: InitialState = {
+async function getRenderData() : Promise<InitialState> {
+  return {
     couldBe: 'anything',
   };
-  return {
-    render: true,
-    initialState,
-  };
 }
+
 
 /**
  * Entry point for the `Render` Extension Point
@@ -75,9 +77,9 @@ export function App() {
   return (
     <BlockStack>
       <CalloutBanner
-        title={`The body of this page was rendered by ${extensionPoint}`}
+        title="TEMPLATE"
       >
-        subtext
+        Use this template as a starting point to build a great post-purchase extension.
       </CalloutBanner>
       {/* <Layout />
        * `500` represents `500px`
@@ -91,27 +93,17 @@ export function App() {
         ]}
       >
         <BlockStack>
-          <Heading>Left Column</Heading>
-          <Image source="https://cdn.shopify.com/assets/images/logos/shopify-bag.png" />
+          <Image source="https://cdn.shopify.com/s/files/1/0506/0709/6002/t/5/assets/placeholder_600x.png" />
         </BlockStack>
-        <BlockStack alignment="leading">
+        <BlockStack alignment="leading" spacing="xloose">
           <TextContainer>
-            <Heading>Right Column</Heading>
-            <HeadingGroup>
-              <Heading>My Post-Purchase Extension</Heading>
-              <TextBlock>
-                It could be a cross-sell extension, product review for past
-                purchases, request for more information from the buyer, or
-                anything else
-              </TextBlock>
-              <HeadingGroup>
-                <Heading>Description</Heading>
-                <TextBlock>
-                  This is a non-exhaustive example, demonstrating provided UI
-                  components
-                </TextBlock>
-              </HeadingGroup>
-            </HeadingGroup>
+            <Heading>Post-Purchase Extension</Heading>
+            <TextBlock>
+              Here you can cross-sell other products, request a product review based on a previous purchase, and much more.
+            </TextBlock>
+            <TextBlock>
+              Learn more about <Link to="https://shopify.dev"> creating great user experiences for post-purchase offers</Link>.
+            </TextBlock>
           </TextContainer>
           <Button
             onPress={() => {
@@ -119,29 +111,8 @@ export function App() {
               console.log(`Extension point ${extensionPoint}`, initialState);
             }}
           >
-            Log extension point to console
+            Primary button
           </Button>
-        </BlockStack>
-      </Layout>
-      <Layout maxInlineSize={0.8}>
-        <BlockStack>
-          <Separator />
-          <TextContainer spacing="loose" alignment="center">
-            <TextBlock>
-              Bottom Text <Text emphasized>Stretches </Text>
-              across both columns. Bottom Text Stretches across both columns.
-              Bottom Text Stretches across both columns. Bottom Text Stretches
-              across both columns. Bottom Text Stretches across both columns.
-              Bottom Text Stretches across both columns.
-            </TextBlock>
-            <TextBlock>
-              In the <Text role="deletion">First</Text> Second Paragraph, Bottom
-              Text Stretches across both columns. Bottom Text Stretches across
-              both columns. Bottom Text Stretches across both columns. Bottom
-              Text Stretches across both columns. Bottom Text Stretches across
-              both columns. Bottom Text Stretches across both columns.
-            </TextBlock>
-          </TextContainer>
         </BlockStack>
       </Layout>
     </BlockStack>

--- a/scripts/generate/templates/post-purchase/src/index.tsx
+++ b/scripts/generate/templates/post-purchase/src/index.tsx
@@ -18,7 +18,6 @@ import {
   Heading,
   Image,
   Layout,
-  Link,
   TextBlock,
   TextContainer,
   View,
@@ -97,13 +96,6 @@ export function App() {
             <TextBlock>
               Here you can cross-sell other products, request a product review
               based on a previous purchase, and much more.
-            </TextBlock>
-            <TextBlock>
-              Learn more about{' '}
-              <Link to="https://shopify.dev" external>
-                creating great user experiences for post-purchase offers
-              </Link>
-              .
             </TextBlock>
           </TextContainer>
           <Button

--- a/scripts/generate/templates/post-purchase/src/index.tsx
+++ b/scripts/generate/templates/post-purchase/src/index.tsx
@@ -8,7 +8,7 @@
  *     completes
  */
 
- import {
+import {
   extend,
   render,
   useExtensionInput,
@@ -77,17 +77,18 @@ export function App() {
   const initialState = storage.initialData as InitialState;
 
   return (
-    <BlockStack>
+    <BlockStack spacing="loose">
       <CalloutBanner
         title="Post-purchase extension template"
       >
         Use this template as a starting point to build a great post-purchase extension.
       </CalloutBanner>
       <Layout
+        maxInlineSize={0.95}
         media={[
-          {viewportSize: 'small', sizes: [1, 30, 1], maxInlineSize: 0.95},
-          {viewportSize: 'medium', sizes: [300, 30, 0.5], maxInlineSize: 0.95},
-          {viewportSize: 'large', sizes: [400, 30, 0.33], maxInlineSize: 0.95},
+          {viewportSize: 'small', sizes: [1, 30, 1]},
+          {viewportSize: 'medium', sizes: [300, 30, 0.5]},
+          {viewportSize: 'large', sizes: [400, 30, 0.33]},
         ]}
       >
         <View>

--- a/scripts/generate/templates/post-purchase/src/index.tsx
+++ b/scripts/generate/templates/post-purchase/src/index.tsx
@@ -77,7 +77,7 @@ export function App() {
   return (
     <BlockStack>
       <CalloutBanner
-        title="TEMPLATE"
+        title="Post-purchase extension template"
       >
         Use this template as a starting point to build a great post-purchase extension.
       </CalloutBanner>
@@ -95,17 +95,17 @@ export function App() {
         <BlockStack>
           <Image source="https://cdn.shopify.com/s/files/1/0506/0709/6002/t/5/assets/placeholder_600x.png" />
         </BlockStack>
-        <BlockStack alignment="leading" spacing="xloose">
+        <BlockStack spacing="extraLoose">
           <TextContainer>
-            <Heading>Post-Purchase Extension</Heading>
+            <Heading>Post-purchase extension</Heading>
             <TextBlock>
               Here you can cross-sell other products, request a product review based on a previous purchase, and much more.
             </TextBlock>
             <TextBlock>
-              Learn more about <Link to="https://shopify.dev"> creating great user experiences for post-purchase offers</Link>.
+              Learn more about <Link to="https://shopify.dev" external>creating great user experiences for post-purchase offers</Link>.
             </TextBlock>
           </TextContainer>
-          <Button
+          <Button fill
             onPress={() => {
               // eslint-disable-next-line no-console
               console.log(`Extension point ${extensionPoint}`, initialState);

--- a/scripts/generate/templates/post-purchase/src/index.tsx
+++ b/scripts/generate/templates/post-purchase/src/index.tsx
@@ -8,7 +8,7 @@
  *     completes
  */
 
-import {
+ import {
   extend,
   render,
   useExtensionInput,
@@ -21,6 +21,7 @@ import {
   Link,
   TextBlock,
   TextContainer,
+  View
 } from '@shopify/argo-post-purchase-react';
 
 
@@ -38,8 +39,8 @@ interface InitialState {
  * extension point.
  */
  extend('Checkout::PostPurchase::ShouldRender', async ({storage}) => {
-  const render = true;
   const initialState = await getRenderData();
+  const render = true;
 
   if (render) {
     // Saves initial state, provided to `Render` via `storage.initialData`
@@ -74,6 +75,7 @@ export function App() {
     'Checkout::PostPurchase::Render'
   >();
   const initialState = storage.initialData as InitialState;
+
   return (
     <BlockStack>
       <CalloutBanner
@@ -81,21 +83,18 @@ export function App() {
       >
         Use this template as a starting point to build a great post-purchase extension.
       </CalloutBanner>
-      {/* <Layout />
-       * `500` represents `500px`
-       * `0.5` represents `50%`
-       * `1` represents `100%` */}
       <Layout
         media={[
-          {viewportSize: 'small', sizes: [1, 1], maxInlineSize: 0.95},
-          {viewportSize: 'medium', sizes: [300, 0.5], maxInlineSize: 0.95},
-          {viewportSize: 'large', sizes: [300, 0.3], maxInlineSize: 0.95},
+          {viewportSize: 'small', sizes: [1, 30, 1], maxInlineSize: 0.95},
+          {viewportSize: 'medium', sizes: [300, 30, 0.5], maxInlineSize: 0.95},
+          {viewportSize: 'large', sizes: [400, 30, 0.33], maxInlineSize: 0.95},
         ]}
       >
-        <BlockStack>
-          <Image source="https://cdn.shopify.com/s/files/1/0506/0709/6002/t/5/assets/placeholder_600x.png" />
-        </BlockStack>
-        <BlockStack spacing="extraLoose">
+        <View>
+          <Image source="https://cdn.shopify.com/static/images/examples/img-placeholder-1120x1120.png" />
+        </View>
+        <View />
+        <BlockStack spacing="xloose">
           <TextContainer>
             <Heading>Post-purchase extension</Heading>
             <TextBlock>
@@ -105,7 +104,7 @@ export function App() {
               Learn more about <Link to="https://shopify.dev" external>creating great user experiences for post-purchase offers</Link>.
             </TextBlock>
           </TextContainer>
-          <Button fill
+          <Button submit
             onPress={() => {
               // eslint-disable-next-line no-console
               console.log(`Extension point ${extensionPoint}`, initialState);


### PR DESCRIPTION
Fix https://github.com/Shopify/checkout-web/issues/3807
Fix #44 

## Note for tech reviewers

⚠️ To avoid confusion, please note that [`post-purcase` UI components](https://github.com/Shopify/argo/tree/main/packages/argo-post-purchase) are not exactly the same as the [`checkout` UI components](https://github.com/Shopify/argo/tree/main/packages/argo-checkout) (they're an older version of the checkout UI components).       

## Notes for UX reviewers

The current template (see screenshots below) is slightly different than [the Figma](https://www.figma.com/file/zIw2Hh2GGG548qDmQ83hqP/Post-Purchase-Extension-Template?node-id=0%3A1). 
Specifically, we removed the paragraph containing a links to the docs, because the relevant docs page isn't available yet. We'll add it to the template, once the relevant docs page is available.

## 🎩  instructions

 1. Make sure you have both `shopify-app-cli` and `argo-checkout-template` repos cloned on your machine
 2. Temporarily hack `shopify-app-cli` to clone the starter code from your local machine.      
     This can be done by changing [this line](https://github.com/Shopify/shopify-app-cli/blob/master/lib/shopify-cli/git.rb#L51) to be (don't forget to replace `YOUR_USERNAME` with the correct value)

    ```rb
    clone_progress("clone", "--single-branch", "/Users/YOUR_USERNAME/src/github.com/Shopify/argo-checkout-template", dest, ctx: ctx)
    ```
 3. Create the extension
 
    ```sh
     ~/src/github.com/Shopify/shopify-app-cli/bin/shopify create extension
    ```

 4. Serve the extension with `shopify serve`, place a test order on your store, and make sure that the post-purchase page looks good.

**IMPORTANT:** Please 🎩  all 4 options (react/vanilla x TypeScript/JavaScript)


## Screenshots

Large layout:

![image](https://user-images.githubusercontent.com/6747775/121243735-10deeb80-c86c-11eb-84f8-f5e824ac5fc4.png)

Medium layout:

![image](https://user-images.githubusercontent.com/6747775/121243816-281dd900-c86c-11eb-95f0-72185dca53f2.png)


Small layout:

![image](https://user-images.githubusercontent.com/6747775/121243853-34a23180-c86c-11eb-8512-59541d5e0589.png)


