### PR TITLE
Add template for metafields config for checkout argo extensions

### DIFF
--- a/scripts/generate/templates/checkout/files/extension.config.yml
+++ b/scripts/generate/templates/checkout/files/extension.config.yml
@@ -1,3 +1,8 @@
 ---
 extension_points:
   - Checkout::Feature::Render
+# metafields:
+#   - namespace: my-namespace
+#     key: my-key
+#   - namespace: my-namespace
+#     key: my-key-2


### PR DESCRIPTION
Adding a template for metafields in the config file so that extension developers know how to specify metafields namespace and key pairs that will be used by the `appMetafields` API